### PR TITLE
added onReady to .init

### DIFF
--- a/server_interface/server_interface.js
+++ b/server_interface/server_interface.js
@@ -197,7 +197,7 @@
 		* up the websocket that will be used to communicate to the server, and to recieve
 		* information from the server.
 		*/
-		init: function(server, isSecure) {
+		init: function(server, isSecure, onReady) {
 			var types = this.messageTypes;
 			var self = this; // for the events
 			
@@ -222,6 +222,12 @@
 
 			socket.onmessage = function(message) {
 				self.incomingMessages.push(message);
+			}
+
+			socket.onopen = onReady;
+
+			socket.onerror = function() {
+				this.socket = null;
 			}
 
 			this.socket = socket;


### PR DESCRIPTION
Now, when initializing the API, you can pass in a function to be run when the socket is ready. Also, now, if the socket were to fail, it is set to null in the API so the API's methods that interact with the socket will no longer work.