### PR TITLE
using empty protocol in links is now a bad practice - long live https

### DIFF
--- a/cardshifter.html
+++ b/cardshifter.html
@@ -12,7 +12,7 @@
 
     <!-- AngularJS libraries -->
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.25/angular.min.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.25/angular-route.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.25/angular-route.js"></script>
 
     <!-- The API for communicating with the server -->
     <script src="server_interface/server_interface.js"></script>


### PR DESCRIPTION
See http://www.paulirish.com/2010/the-protocol-relative-url/ for more information. Relevant excerpt:

> Now that SSL is encouraged for everyone and doesn't have performance concerns, this technique is now an anti-pattern.
> If the asset you need is available on SSL, then always use the https:// asset.

Fixes #44 