### PR TITLE
do not uglify vendor modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The Cardshifter client",
   "main": "src/cardshifter.js",
   "scripts": {
-    "build": "webpack --config webpack.config.js --optimize-minimize --devtool source-map",
+    "build": "webpack --config webpack.config.js --devtool source-map",
     "develop": "webpack-dev-server",
     "test": "karma start"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
   plugins: [
     new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.js'),
     new webpack.optimize.UglifyJsPlugin({
-      include: /src/
+      include: 'cardshifter.js'
     }),
     new ngAnnotatePlugin()
   ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,9 @@ module.exports = {
   },
   plugins: [
     new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.js'),
+    new webpack.optimize.UglifyJsPlugin({
+      include: /src/
+    }),
     new ngAnnotatePlugin()
   ],
   devServer: {


### PR DESCRIPTION
currently vendor modules are being uglified by webpack, which significantly increases compile time.
this corrects that mistake. the intention is for in development for us to use the separate vendor file, but at runtime we should replace that vendor file with cdn links.