### PR TITLE
Correct license property in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "Francis Veilleux-Gaboury <Phrancis@users.noreply.github.com> (http://www.github.com/Phrancis)",
     "SirPython <SirPython@users.noreply.github.com> (http://www.github.com/SirPython)"
   ],
-  "license": "ISC",
+  "license": "AFL-2.0",
   "bugs": {
     "url": "https://github.com/Cardshifter/HTML-Client/issues"
   },


### PR DESCRIPTION
The SPDX identifier for the Apache 2.0 license is AFL-2.0.